### PR TITLE
Add Sony UK revision code for RaspberryPi 2B v1.2

### DIFF
--- a/hardware/raspberrypi/revision-codes/README.md
+++ b/hardware/raspberrypi/revision-codes/README.md
@@ -104,6 +104,7 @@ New-style revision codes in use:
 | a02082 | 3B                | 1.2      | 1GB   | Sony UK      |
 | a020a0 | CM3               | 1.0      | 1GB   | Sony UK      |
 | a020d3 | 3B+               | 1.3      | 1GB   | Sony UK      |
+| a02042 | 2B (with BCM2837) | 2.0      | 1GB   | Sony UK      |
 | a21041 | 2B                | 1.1      | 1GB   | Embest       |
 | a22042 | 2B (with BCM2837) | 1.2      | 1GB   | Embest       |
 | a22082 | 3B                | 1.2      | 1GB   | Embest       |


### PR DESCRIPTION
This adds in the RPi2 v1.2 from Sony UK to the revision list.  I made the Revision 2.0 as that's how I read the revision code itself, so it may be incorrect.